### PR TITLE
Support Data requests in StorageRequest

### DIFF
--- a/Sources/GoogleCloudProvider/Storage/API/StorageObjectAPI.swift
+++ b/Sources/GoogleCloudProvider/Storage/API/StorageObjectAPI.swift
@@ -12,6 +12,7 @@ public protocol StorageObjectAPI {
     func copy(destinationBucket: String, destinationObject: String, sourceBucket: String, sourceObject: String, object: GoogleStorageObject, queryParameters: [String: String]?) throws -> Future<GoogleStorageObject>
     func delete(bucket: String, objectName: String, queryParameters: [String: String]?) throws -> Future<EmptyResponse>
     func get(bucket: String, objectName: String, queryParameters: [String: String]?) throws -> Future<GoogleStorageObject>
+    func getMedia(bucket: String, objectName: String, queryParameters: [String: String]?) throws -> Future<Data>
     func createSimpleUpload(bucket: String, data: Data, name: String, mediaType: MediaType, queryParameters: [String: String]?) throws -> Future<GoogleStorageObject>
     func list(bucket: String, queryParameters: [String: String]?) throws -> Future<StorageObjectList>
     func patch(bucket: String, objectName: String, object: GoogleStorageObject?, queryParameters: [String: String]?) throws -> Future<GoogleStorageObject>
@@ -72,13 +73,24 @@ public class GoogleStorageObjectAPI: StorageObjectAPI {
         return try request.send(method: .DELETE, path: "\(endpoint)/\(bucket)/o/\(objectName)", query: queryParams)
     }
     
-    /// Retrieves an object or its metadata.
+    /// Retrieves an object's metadata.
     public func get(bucket: String, objectName: String, queryParameters: [String: String]? = nil) throws -> Future<GoogleStorageObject> {
         var queryParams = ""
         if let queryParameters = queryParameters {
             queryParams = queryParameters.queryParameters
         }
         
+        return try request.send(method: .GET, path: "\(endpoint)/\(bucket)/o/\(objectName)", query: queryParams)
+    }
+
+    /// Retrieves an object's contents.
+    public func getMedia(bucket: String, objectName: String, queryParameters: [String: String]? = nil) throws -> Future<Data> {
+        var queryParams = ["alt": "media"].queryParameters
+
+        if let queryParameters = queryParameters {
+            queryParams = queryParameters.queryParameters
+        }
+
         return try request.send(method: .GET, path: "\(endpoint)/\(bucket)/o/\(objectName)", query: queryParams)
     }
     

--- a/Sources/GoogleCloudProvider/Storage/StorageClient.swift
+++ b/Sources/GoogleCloudProvider/Storage/StorageClient.swift
@@ -9,6 +9,7 @@ import Vapor
 
 enum GoogleCloudStorageClientError: Error {
     case projectIdMissing
+    case unknownError
 }
 
 public struct GoogleCloudStorageClient: ServiceType {

--- a/Sources/GoogleCloudProvider/Storage/StorageRequest.swift
+++ b/Sources/GoogleCloudProvider/Storage/StorageRequest.swift
@@ -40,15 +40,15 @@ public class GoogleCloudStorageRequest {
     
     func send<GCM: GoogleCloudModel>(method: HTTPMethod, headers: HTTPHeaders = [:], path: String, query: String, body: HTTPBody = HTTPBody()) throws -> Future<GCM> {
         return try withToken({ token in
-            return try self.send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
+            return try self._send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
                 return try self.responseDecoder.decode(GCM.self, from: response.http, maxSize: 65_536, on: response)
             })
         })
     }
 
-    func send(method: HTTPMethod, headers: HTTPHeaders = [:], path: String, query: String, body: HTTPBody = HTTPBody()) throws -> Future<Data> {
+    func send(method: HTTPMethod = .GET, headers: HTTPHeaders = [:], path: String, query: String, body: HTTPBody = HTTPBody()) throws -> Future<Data> {
         return try withToken({ token in
-            return try self.send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
+            return try self._send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
                 return response.http.body.consumeData(on: response)
             })
         })
@@ -67,19 +67,21 @@ public class GoogleCloudStorageRequest {
         return try closure(token)
     }
 
-    private func send(method: HTTPMethod, headers: HTTPHeaders, path: String, query: String, body: HTTPBody, accessToken: String) throws -> Future<Response> {
+    private func _send(method: HTTPMethod, headers: HTTPHeaders, path: String, query: String, body: HTTPBody, accessToken: String) throws -> Future<Response> {
         var finalHeaders: HTTPHeaders = HTTPHeaders.gcsDefault
         finalHeaders.add(name: .authorization, value: "Bearer \(accessToken)")
         headers.forEach { finalHeaders.replaceOrAdd(name: $0.name, value: $0.value) }
 
         return httpClient.send(method, headers: finalHeaders, to: "\(path)?\(query)", beforeSend: { $0.http.body = body }).flatMap({ response in
             guard response.http.status == .ok else {
-                return try self.responseDecoder.decode(CloudStorageError.self, from: response.http, maxSize: 65_536, on: self.httpClient.container).map(to: Response.self) { error in
+                _ = try self.responseDecoder.decode(CloudStorageError.self, from: response.http, maxSize: 65_536, on: self.httpClient.container).map { error in
                     throw error
                 }
+
+                throw GoogleCloudStorageClientError.unknownError
             }
 
-            return Future.map(on: response) { response }
+            return response.future(response)
         })
     }
 }

--- a/Sources/GoogleCloudProvider/Storage/StorageRequest.swift
+++ b/Sources/GoogleCloudProvider/Storage/StorageRequest.swift
@@ -18,8 +18,11 @@ extension HTTPHeaders {
 
 public class GoogleCloudStorageRequest {
     let refreshableToken: OAuthRefreshable
-    let httpClient: Client
     let project: String
+
+    let httpClient: Client
+    let responseDecoder: JSONDecoder
+    let dateFormatter: DateFormatter
 
     var currentToken: OAuthAccessToken?
     var tokenCreatedTime: Date?
@@ -28,38 +31,55 @@ public class GoogleCloudStorageRequest {
         self.refreshableToken = oauth
         self.httpClient = httpClient
         self.project = project
+        self.responseDecoder = JSONDecoder()
+        self.dateFormatter = DateFormatter()
+
+        self.dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        self.responseDecoder.dateDecodingStrategy = .formatted(self.dateFormatter)
     }
     
     func send<GCM: GoogleCloudModel>(method: HTTPMethod, headers: HTTPHeaders = [:], path: String, query: String, body: HTTPBody = HTTPBody()) throws -> Future<GCM> {
-        // if oauth token is not expired continue as normal
+        return try withToken({ token in
+            return try self.send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
+                return try self.responseDecoder.decode(GCM.self, from: response.http, maxSize: 65_536, on: response)
+            })
+        })
+    }
 
-        if let token = currentToken, let created = tokenCreatedTime, refreshableToken.isFresh(token: token, created: created) {
-            return try _send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken)
-        } else {
-            return try refreshableToken.refresh().flatMap({ (newToken) in
+    func send(method: HTTPMethod, headers: HTTPHeaders = [:], path: String, query: String, body: HTTPBody = HTTPBody()) throws -> Future<Data> {
+        return try withToken({ token in
+            return try self.send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
+                return response.http.body.consumeData(on: response)
+            })
+        })
+    }
+
+    private func withToken<F>(_ closure: @escaping (OAuthAccessToken) throws -> Future<F>) throws -> Future<F>{
+        guard let token = currentToken, let created = tokenCreatedTime, refreshableToken.isFresh(token: token, created: created) else {
+            return try refreshableToken.refresh().flatMap({ newToken in
                 self.currentToken = newToken
                 self.tokenCreatedTime = Date()
-                return try self._send(method: method, headers: headers, path: path, query: query, body: body, accessToken: newToken.accessToken)
+
+                return try closure(newToken)
             })
         }
+
+        return try closure(token)
     }
-    
-    private func _send<GCM: GoogleCloudModel>(method: HTTPMethod, headers: HTTPHeaders, path: String, query: String, body: HTTPBody, accessToken: String) throws -> Future<GCM> {
+
+    private func send(method: HTTPMethod, headers: HTTPHeaders, path: String, query: String, body: HTTPBody, accessToken: String) throws -> Future<Response> {
         var finalHeaders: HTTPHeaders = HTTPHeaders.gcsDefault
         finalHeaders.add(name: .authorization, value: "Bearer \(accessToken)")
         headers.forEach { finalHeaders.replaceOrAdd(name: $0.name, value: $0.value) }
-        
-        return httpClient.send(method, headers: finalHeaders, to: "\(path)?\(query)", beforeSend: { $0.http.body = body }).flatMap({ (response)  in
-            let decoder = JSONDecoder()
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-            decoder.dateDecodingStrategy = .formatted(formatter)
+
+        return httpClient.send(method, headers: finalHeaders, to: "\(path)?\(query)", beforeSend: { $0.http.body = body }).flatMap({ response in
             guard response.http.status == .ok else {
-                return try decoder.decode(CloudStorageError.self, from: response.http, maxSize: 65_536, on: self.httpClient.container).map(to: GCM.self){ error in
+                return try self.responseDecoder.decode(CloudStorageError.self, from: response.http, maxSize: 65_536, on: self.httpClient.container).map(to: Response.self) { error in
                     throw error
                 }
             }
-            return try decoder.decode(GCM.self, from: response.http, maxSize: 65_536, on: response)
+
+            return Future.map(on: response) { response }
         })
     }
 }


### PR DESCRIPTION
This PR refactors StorageRequest.swift to either decode the response into a GoogleCloudModel, or return the plain Data of the response. The Data method is used for `getMedia`, which is able to get an object's contents from the Google Cloud Storage API with authentication.