### PR TITLE
Add implementation for Google Key Management Service - decrypt

### DIFF
--- a/Sources/GoogleCloud/KMS/CloudKMSError.swift
+++ b/Sources/GoogleCloud/KMS/CloudKMSError.swift
@@ -1,0 +1,46 @@
+//
+//  CloudKMSError.swift
+//  GoogleCloudProvider
+//
+//  Created by Andrei Popa on 11/07/18.
+//
+
+import Foundation
+import Vapor
+
+
+public enum CloudKMSError: Error, Debuggable {
+    
+    case missingEnvironment(variable: String)
+    case other(message: String)
+    
+    public var identifier: String {
+        switch self {
+        case .missingEnvironment: return "missingEnvironment"
+        case .other: return "other"
+        }
+    }
+    
+    public var reason: String {
+        switch self {
+        case let .missingEnvironment(variable):
+            return "Missing environment variable '\(variable)'"
+        case let .other(message): return message
+        }
+    }
+}
+
+
+// =========================================================================
+// error model
+// =========================================================================
+struct KMSError: GoogleCloudModel {
+    
+    var error: KMSErrorBody
+    struct KMSErrorBody: Content {
+        public var code: Int
+        public var message: String
+        public var status: String
+    }
+    
+}

--- a/Sources/GoogleCloud/KMS/KMSAPI.swift
+++ b/Sources/GoogleCloud/KMS/KMSAPI.swift
@@ -1,0 +1,40 @@
+//
+//  ObjectACLAPI.swift
+//  GoogleCloudProvider
+//
+//  Created by Andrew Edwards on 5/20/18.
+//
+
+import Vapor
+
+
+
+public final class GoogleKMSAPI {
+    
+    let endpoint: String
+    let request: GoogleCloudKMSRequest
+    
+    
+    init(request: GoogleCloudKMSRequest) {
+        self.request = request
+        /// Cloud KMS endpoints are bound to location & project ID∫
+        self.endpoint = "https://cloudkms.googleapis.com/v1/projects/\(request.project)/locations/\(request.location)"
+    }
+    
+    
+    /// decrypts ciphertext
+    public func decrypt(keyRing: String, keyName: String, ciphertext: String) throws -> Future<Data> {
+        
+        let googleKMSURI = "\(endpoint)/keyRings/\(keyRing)/cryptoKeys/\(keyName):decrypt"
+        
+        let body = HTTPBody(string: """
+        { "message": "\(ciphertext)"}
+        """)
+        
+        return try request.send(method: .POST, path: googleKMSURI, body: body)
+    }
+    
+    
+
+    
+}

--- a/Sources/GoogleCloud/KMS/KMSAPI.swift
+++ b/Sources/GoogleCloud/KMS/KMSAPI.swift
@@ -1,8 +1,8 @@
 //
-//  ObjectACLAPI.swift
+//  KMSAPI.swift
 //  GoogleCloudProvider
 //
-//  Created by Andrew Edwards on 5/20/18.
+//  Created by Andrei Popa on 11/07/18.
 //
 
 import Vapor
@@ -23,15 +23,20 @@ public final class GoogleKMSAPI {
     
     
     /// decrypts ciphertext
-    public func decrypt(keyRing: String, keyName: String, ciphertext: String) throws -> Future<Data> {
+    public func decrypt(keyRing: String, keyName: String, ciphertext: String) throws -> Future<String> {
+        
+        struct KMSDecryptResponse: Codable {
+            let plaintext: String
+        }
         
         let googleKMSURI = "\(endpoint)/keyRings/\(keyRing)/cryptoKeys/\(keyName):decrypt"
         
         let body = HTTPBody(string: """
-        { "message": "\(ciphertext)"}
-        """)
+            { "ciphertext": "\(ciphertext)"}
+            """)
         
-        return try request.send(method: .POST, path: googleKMSURI, body: body)
+        /// return only the plaintext
+        return try request.send(method: .POST, path: googleKMSURI, body: body, model: KMSDecryptResponse.self).map({ $0.plaintext })
     }
     
     

--- a/Sources/GoogleCloud/KMS/KMSClient.swift
+++ b/Sources/GoogleCloud/KMS/KMSClient.swift
@@ -1,0 +1,58 @@
+//
+//  StorageClient.swift
+//  GoogleCloudProvider
+//
+//  Created by Andrew Edwards on 4/16/18.
+//
+
+import Vapor
+
+
+
+enum GoogleCloudKMSError: Error {
+    case projectIdMissing
+    case unknownError
+}
+
+
+
+public final class GoogleCloudKMSClient {
+    
+    public var api: GoogleKMSAPI
+
+
+    init(providerconfig: GoogleCloudProviderConfig, client: Client) throws {
+        let env = ProcessInfo.processInfo.environment
+
+        // Locate the credentials to use for this client. In order of priority:
+        // - Environment Variable Specified Credentials (GOOGLE_APPLICATION_CREDENTIALS)
+        // - GoogleCloudProviderConfig's .serviceAccountCredentialPath (optionally configured)
+        // - Application Default Credentials, located in the constant
+        let preferredCredentialPath = env["GOOGLE_APPLICATION_CREDENTIALS"] ??
+                                  providerconfig.serviceAccountCredentialPath ??
+                                  "~/.config/gcloud/application_default_credentials.json"
+
+        // A token implementing OAuthRefreshable. Loaded from credentials defined above.
+        let refreshableToken = try OAuthCredentialLoader.getRefreshableToken(credentialFilePath: preferredCredentialPath, withClient: client)
+
+        // Set the projectId to use for this client. In order of priority:
+        // - Environment Variable (PROJECT_ID)
+        // - GoogleCloudProviderConfig's .project (optionally configured)
+        guard let projectId = env["PROJECT_ID"] ?? providerconfig.project ?? (refreshableToken as? OAuthServiceAccount)?.credentials.projectId else {
+            throw GoogleCloudStorageClientError.projectIdMissing
+        }
+
+        // TODO: extract location into env["LOCATION"]
+        let kmsRequest = GoogleCloudKMSRequest(httpClient: client, oauth: refreshableToken, project: projectId, location: "europe-west4")
+
+        // initialize API
+        api = GoogleKMSAPI(request: kmsRequest)
+    }
+
+
+    public static func makeService(for worker: Container) throws -> GoogleCloudKMSClient {
+        let client = try worker.make(Client.self)
+        let providerConfig = try worker.make(GoogleCloudProviderConfig.self)
+        return try GoogleCloudKMSClient(providerconfig: providerConfig, client: client)
+    }
+}

--- a/Sources/GoogleCloud/KMS/KMSClient.swift
+++ b/Sources/GoogleCloud/KMS/KMSClient.swift
@@ -1,54 +1,70 @@
 //
-//  StorageClient.swift
+//  KMSClient.swift
 //  GoogleCloudProvider
 //
-//  Created by Andrew Edwards on 4/16/18.
+//  Created by Andrei Popa on 11/07/18.
 //
 
 import Vapor
 
 
 
-enum GoogleCloudKMSError: Error {
-    case projectIdMissing
-    case unknownError
+
+
+public struct KMSScope {
+    /// preferred because it supports the principle of least privilege
+    public static let defaultScope = "https://www.googleapis.com/auth/cloudkms"
 }
 
 
 
-public final class GoogleCloudKMSClient {
+
+
+
+public final class GoogleCloudKMSClient: ServiceType {
     
     public var api: GoogleKMSAPI
 
 
-    init(providerconfig: GoogleCloudProviderConfig, client: Client) throws {
+    public init(providerconfig: GoogleCloudProviderConfig, client: Client) throws {
         let env = ProcessInfo.processInfo.environment
-
+        
         // Locate the credentials to use for this client. In order of priority:
         // - Environment Variable Specified Credentials (GOOGLE_APPLICATION_CREDENTIALS)
         // - GoogleCloudProviderConfig's .serviceAccountCredentialPath (optionally configured)
         // - Application Default Credentials, located in the constant
-        let preferredCredentialPath = env["GOOGLE_APPLICATION_CREDENTIALS"] ??
-                                  providerconfig.serviceAccountCredentialPath ??
-                                  "~/.config/gcloud/application_default_credentials.json"
-
-        // A token implementing OAuthRefreshable. Loaded from credentials defined above.
-        let refreshableToken = try OAuthCredentialLoader.getRefreshableToken(credentialFilePath: preferredCredentialPath, withClient: client)
-
+        let credentialPath = env["GOOGLE_APPLICATION_CREDENTIALS"] ??
+            providerconfig.serviceAccountCredentialPath ??
+        "~/.config/gcloud/application_default_credentials.json"
+        
+        // project location
+        guard let location = env["GOOGLE_LOCATION"] else {
+            throw CloudKMSError.missingEnvironment(variable: "GOOGLE_LOCATION")
+        }
+        
+        // credentials
+        let credentials = try GoogleServiceAccountCredentials(contentsOfFile: credentialPath)
+        // token
+        let refreshableToken = OAuthServiceAccount(credentials: credentials, scopes: [KMSScope.defaultScope], httpClient: client)
+        
         // Set the projectId to use for this client. In order of priority:
         // - Environment Variable (PROJECT_ID)
         // - GoogleCloudProviderConfig's .project (optionally configured)
-        guard let projectId = env["PROJECT_ID"] ?? providerconfig.project ?? (refreshableToken as? OAuthServiceAccount)?.credentials.projectId else {
-            throw GoogleCloudStorageClientError.projectIdMissing
-        }
+        let projectId = env["PROJECT_ID"] ?? providerconfig.project ?? refreshableToken.credentials.projectId
+        
 
-        // TODO: extract location into env["LOCATION"]
-        let kmsRequest = GoogleCloudKMSRequest(httpClient: client, oauth: refreshableToken, project: projectId, location: "europe-west4")
-
+        // prepare generic request
+        let kmsRequest = GoogleCloudKMSRequest(httpClient: client, oauth: refreshableToken, project: projectId, location: location)
+        
         // initialize API
         api = GoogleKMSAPI(request: kmsRequest)
     }
 
+    // ==================================================================
+    // service
+    // ==================================================================
+    
+    public static var serviceSupports: [Any.Type] { return [GoogleCloudKMSClient.self] }
 
     public static func makeService(for worker: Container) throws -> GoogleCloudKMSClient {
         let client = try worker.make(Client.self)

--- a/Sources/GoogleCloud/KMS/KMSRequest.swift
+++ b/Sources/GoogleCloud/KMS/KMSRequest.swift
@@ -1,0 +1,119 @@
+//
+//  StorageRequest.swift
+//  GoogleCloudProvider
+//
+//  Created by Andrew Edwards on 5/19/18.
+//
+
+import Vapor
+
+
+
+public final class GoogleCloudKMSRequest {
+    let refreshableToken: OAuthRefreshable
+    let project: String
+    let location: String
+
+    let httpClient: Client
+    let responseDecoder: JSONDecoder
+    let dateFormatter: DateFormatter
+
+    var currentToken: OAuthAccessToken?
+    var tokenCreatedTime: Date?
+    
+    
+    init(httpClient: Client, oauth: OAuthRefreshable, project: String, location: String) {
+        self.refreshableToken = oauth
+        self.httpClient = httpClient
+        self.project = project
+        self.location = location
+        self.responseDecoder = JSONDecoder()
+        self.dateFormatter = DateFormatter()
+
+        self.dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        self.responseDecoder.dateDecodingStrategy = .formatted(self.dateFormatter)
+    }
+    
+    
+    
+    func send<GCM: GoogleCloudModel>(method: HTTPMethod,
+                                     headers: HTTPHeaders = [:],
+                                     path: String,
+                                     query: String? = nil,
+                                     body: HTTPBody = HTTPBody()) throws -> Future<GCM> {
+        return try withToken({ token in
+            return try self._send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
+                return try self.responseDecoder.decode(GCM.self, from: response.http, maxSize: 65_536, on: response)
+            })
+        })
+    }
+
+    
+    func send(method: HTTPMethod = .GET,
+              headers: HTTPHeaders = [:],
+              path: String,
+              query: String? = nil,
+              body: HTTPBody = HTTPBody()) throws -> Future<Data> {
+        
+        return try withToken({ token in
+            return try self._send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
+                return response.http.body.consumeData(on: response)
+            })
+        })
+    }
+
+    
+
+    private func _send(method: HTTPMethod,
+                       headers: HTTPHeaders,
+                       path: String,
+                       query: String? = nil,
+                       body: HTTPBody,
+                       accessToken: String) throws -> Future<Response> {
+        
+        // add Bearer token header
+        var finalHeaders: HTTPHeaders = HTTPHeaders.gcsDefault
+        finalHeaders.add(name: .authorization, value: "Bearer \(accessToken)")
+        headers.forEach { finalHeaders.replaceOrAdd(name: $0.name, value: $0.value) }
+        
+        // if we have a query, append
+        var to: String {
+            if let query = query {
+                return "\(path)?\(query)"
+            }
+            return path
+        }
+
+        // perform HTTP request
+        return httpClient.send(method, headers: finalHeaders, to: to, beforeSend: { $0.http.body = body }).flatMap({ response in
+            guard response.http.status == .ok else {
+                print(response)
+                return try self.responseDecoder.decode(CloudStorageError.self, from: response.http, maxSize: 65_536, on: self.httpClient.container).map { error in
+                    throw error
+                    }.catchMap { error -> Response in
+                        throw GoogleCloudKMSError.unknownError
+                }
+            }
+            return response.future(response)
+        })
+    }
+    
+    
+    // =========================================================================
+    // to generalize
+    // =========================================================================
+    
+    private func withToken<F>(_ closure: @escaping (OAuthAccessToken) throws -> Future<F>) throws -> Future<F>{
+        guard let token = currentToken, let created = tokenCreatedTime, refreshableToken.isFresh(token: token, created: created) else {
+            return try refreshableToken.refresh().flatMap({ newToken in
+                self.currentToken = newToken
+                self.tokenCreatedTime = Date()
+                
+                return try closure(newToken)
+            })
+        }
+        
+        return try closure(token)
+    }
+    
+}


### PR DESCRIPTION
The implementation follows the lines of CloudStorage implementation, but I guess we could generalize parts of the code, at least unifying some of the network requests. For now, it's only the decrypt functionality. If people need it, I can easily implement create/encrypt as well.