### PR TITLE
Fixed Decoding EmptyResponse Type

### DIFF
--- a/Sources/GoogleCloud/Storage/StorageRequest.swift
+++ b/Sources/GoogleCloud/Storage/StorageRequest.swift
@@ -40,6 +40,10 @@ public final class GoogleCloudStorageRequest {
     func send<GCM: GoogleCloudModel>(method: HTTPMethod, headers: HTTPHeaders = [:], path: String, query: String, body: HTTPBody = HTTPBody()) throws -> Future<GCM> {
         return try withToken({ token in
             return try self._send(method: method, headers: headers, path: path, query: query, body: body, accessToken: token.accessToken).flatMap({ response in
+                if GCM.self is EmptyResponse.Type && response.http.body.data == Data() {
+                    response.http.body = HTTPBody(staticString: "{}")
+                }
+                
                 return try self.responseDecoder.decode(GCM.self, from: response.http, maxSize: 65_536, on: response)
             })
         })

--- a/Sources/GoogleCloud/Storage/StorageRequest.swift
+++ b/Sources/GoogleCloud/Storage/StorageRequest.swift
@@ -72,7 +72,7 @@ public final class GoogleCloudStorageRequest {
         headers.forEach { finalHeaders.replaceOrAdd(name: $0.name, value: $0.value) }
 
         return httpClient.send(method, headers: finalHeaders, to: "\(path)?\(query)", beforeSend: { $0.http.body = body }).flatMap({ response in
-            guard response.http.status == .ok else {
+            guard (200...299).contains(response.http.status.code) else {
                 return try self.responseDecoder.decode(CloudStorageError.self, from: response.http, maxSize: 65_536, on: self.httpClient.container).map { error in
                     throw error
                     }.catchMap { error -> Response in


### PR DESCRIPTION
When an object is deleted from a bucket, Google Cloud returns a 204 response with no body. This is expected from a RESTfull perspective, but several assumptions where made in this package that caused it to throw errors:

1. All successful responses have a status code of `200`. This is incorrect. A success code is any code in the range of `200...299`.
2. You can always decode an empty `Decodable` type from a response body. This is incorrect because if you have an empty response with no data, that is considered invalid JSON and you get an error.

Both of these issues have been fixed, though the first one is much cleaner while the second is a bit of a monkey wrenching. 