### PR TITLE
Lock google-cloud-kit dependency version at `1.0.0-rc.9` until we bump `swift-tools` and `macOS` version to `5.7` and `v13` respectively

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        .package(url: "https://github.com/vapor-community/google-cloud-kit.git", .exact("1.0.0-rc.7")),
+        .package(url: "https://github.com/vapor-community/google-cloud-kit.git", .exact("1.0.0-rc.9")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        .package(url: "git@github.com:Clearcals/google-cloud-kit.git", .branch("master"))
+        .package(url: "git@github.com:Clearcals/google-cloud-kit.git", from: "1.0.0-rc.7")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        .package(url: "https://github.com/vapor-community/google-cloud-kit.git", from: "1.0.0-rc.7")
+        .package(url: "https://github.com/vapor-community/google-cloud-kit.git", .exact("1.0.0-rc.7")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
As the `google-cloud-kit` repo changed the min version of swift-tools to `5.7` and macOS to `v13` in `1.0.0-rc.9`, locking the `google-cloud-kit` version to `1.0.0-rc.9`. We can change this once we decide to bump up the versions.